### PR TITLE
More cleanup

### DIFF
--- a/SOURCES/misp-2.4.177-fix-composer-config.patch
+++ b/SOURCES/misp-2.4.177-fix-composer-config.patch
@@ -1,0 +1,12 @@
+--- app/composer.json.orig	2023-10-13 16:23:39.533220785 +0200
++++ app/composer.json	2023-10-13 16:23:24.778215419 +0200
+@@ -47,7 +47,8 @@
+         "vendor-dir": "Vendor",
+         "optimize-autoloader": true,
+         "allow-plugins": {
+-            "composer/installers": true
++            "composer/installers": true,
++            "php-http/discovery": true
+         }
+     }
+ }

--- a/SPECS/misp8.spec
+++ b/SPECS/misp8.spec
@@ -32,6 +32,7 @@ Source6:    	start-misp-workers.sh
 Source7:	misp-workers.ini
 Source8:	misp-workers8.pp
 Patch0:     	MISP-AppModel.php.patch
+Patch1: 	misp-2.4.177-fix-composer-config.patch
 
 BuildRequires:	/usr/bin/pathfix.py
 BuildRequires:  git, %{pythonver_short}-devel, %{pythonver_short}-pip
@@ -75,6 +76,7 @@ git config core.filemode false
 # patch app/Model/Server.php to show commit ID
 patch --ignore-whitespace -p0 < %{PATCH0}
 
+patch --ignore-whitespace -p0 < %{PATCH1}
 
 %build
 # intentionally left blank

--- a/SPECS/misp8.spec
+++ b/SPECS/misp8.spec
@@ -154,8 +154,14 @@ find . -name \.git | xargs -i rm -rf {}
 pushd $RPM_BUILD_ROOT/var/www/MISP
 # developement
 rm -rf build
+rm -rf debian
+rm -rf misp-vagrant
+rm -rf tests
+rm -rf travis
 rm -f build-deb.sh
 rm -f requirements.txt
+rm -f Pipfile
+rm -f .coveragerc
 rm -f app/composer.*
 rm -f app/Makefile
 rm -f app/update_thirdparty.sh
@@ -172,6 +178,11 @@ rm -f README.debian
 rm -f README.md
 rm -f ROADMAP.md
 rm -f SECURITY.md
+
+# useless installation files, excepted mysql schema
+rm -rf INSTALL
+mkdir INSTALL
+cp $RPM_BUILD_DIR/%{name}-%{version}/MISP/INSTALL/MYSQL.sql INSTALL
 popd
 
 mkdir -p $RPM_BUILD_ROOT/etc/httpd/conf.d


### PR DESCRIPTION
Hello, here are two new commits. The first one removes a bunch of files uneeded at runtime, such as developement files, debian packaging files, or installation guides. The second avoids interruption during installation.