### PR TITLE
Create misp-worker-status-supervisord.te

### DIFF
--- a/SOURCES/misp-worker-status-supervisord.te
+++ b/SOURCES/misp-worker-status-supervisord.te
@@ -1,0 +1,5 @@
+policy_module(misp-worker-status-supervisord, 1.0)
+gen_require(`
+  type httpd_t;
+')
+domain_read_all_domains_state(httpd_t)


### PR DESCRIPTION
The policy being created by this te file allows MISP to read the /proc filesystem and therefore show the worker's status when these have been migrated to supervisord (SimpleBackgroundJobs).

Please create the corresponding SELinux policy based on this te file and include it in the provided RPMs.