### PR TITLE
Update misp-modules to 2.4.199

### DIFF
--- a/SPECS/misp-modules8.spec
+++ b/SPECS/misp-modules8.spec
@@ -14,7 +14,7 @@
 %global __requires_exclude ^lib.*\-[0-9a-f]{8}.so.*$
 
 Name:		misp-modules
-Version:	2.4.198
+Version:	2.4.199
 Release:	1%{?dist}
 Summary:	MISP modules for expansion services, import and export
 
@@ -89,6 +89,9 @@ find $RPM_BUILD_ROOT%{venvbasedir} -name ".git" -exec rm -rf "{}" \;
 semodule -i /usr/share/MISP-modules/policy/selinux/misp-modules8.pp
 
 %changelog
+* Tue Nov 26 2024 highpingblorg <highpingblorg@users.noreply.github.com> - 2.4.199
+- update to 2.4.199
+
 * Tue Oct 8 2024 Andreas Muehlemann <amuehlem@gmail.com> - 2.4.198
 - update to 2.4.198
 

--- a/SPECS/misp-modules9.spec
+++ b/SPECS/misp-modules9.spec
@@ -14,7 +14,7 @@
 %global __requires_exclude ^lib.*\-[0-9a-f]{8}.so.*$
 
 Name:		misp-modules
-Version:	2.4.198
+Version:	2.4.199
 Release:	1%{?dist}
 Summary:	MISP modules for expansion services, import and export
 
@@ -89,6 +89,9 @@ find $RPM_BUILD_ROOT%{venvbasedir} -name ".git" -exec rm -rf "{}" \;
 semodule -i /usr/share/MISP-modules/policy/selinux/misp-modules8.pp
 
 %changelog
+* Tue Nov 26 2024 highpingblorg <highpingblorg@users.noreply.github.com> - 2.4.199
+- update to 2.4.199
+
 * Tue Oct 8 2024 Andreas Muehlemann <amuehlem@gmail.com> - 2.4.198
 - update to 2.4.198
 


### PR DESCRIPTION
On November 24th version 2.4.199 for MISP Modules was released. The current version in the MISP repo is 2.4.198.

```
➜  ~ dnf info misp-modules
Last metadata expiration check: 1:14:03 ago on Tue Nov 26 13:17:09 2024.
Available Packages
Name         : misp-modules
Version      : 2.4.198
Release      : 1.el8
Architecture : x86_64
Size         : 140 M
Source       : misp-modules-2.4.198-1.el8.src.rpm
Repository   : misp
Summary      : MISP modules for expansion services, import and export
URL          : https://github.com/MISP/misp-modules
License      : GPLv3
Description  : MISP modules for expansion services, import and export
```