### PR TITLE
Update RHEL9.md to MISP 2.5 (PHP Version 8.3)

### DIFF
--- a/RHEL9.md
+++ b/RHEL9.md
@@ -73,11 +73,11 @@ systemctl start misp-workers
 
 - configure php
 
-all php settings are done in ```/etc/opt/remi/php74/php.ini```
+all php settings are done in ```/etc/opt/remi/php83/php.ini```
 
 - link php
 ```
-ln -s /bin/php74 /bin/php
+ln -s /bin/php83 /bin/php
 ```
 
 - start redis
@@ -98,8 +98,8 @@ systemctl start httpd
 
 ```
 # enable php-fpm at startup
-systemctl enable php74-php-fpm
-systemctl start php74-php-fpm
+systemctl enable php83-php-fpm
+systemctl start php83-php-fpm
 ```
 
 - open firewall


### PR DESCRIPTION
Hi, 

Thanks for maintaining this repository.  
While installing on Rocky Linux 9 / RHEL 9 with MISP 2.5, I noticed that the PHP version in the documentation was outdated.  

Changes made:

- Updated PHP version references from 7.4 to 8.3
- Adjusted paths and service names accordingly in RHEL9.md

Tested with on Rocky Linux 9 and it works as expected.
