### PR TITLE
Update RHEL9.md

### DIFF
--- a/RHEL9.md
+++ b/RHEL9.md
@@ -18,9 +18,9 @@ dnf install https://repo.misp-project.ch/yum/misp9/misp-release-latest.el9.noarc
 dnf install misp misp-python-virtualenv
 ```
 
-## install MariaDB, if you want to use an external DB, only MariaDB-client is needed
+## install MariaDB, if you want to use an external DB, only mariadb is needed
 ```
-dnf install MariaDB-client MariaDB-server
+dnf install mariadb-server mariadb
 ```
 
 ## configuration


### PR DESCRIPTION
fix(RHEL9): use correct MariaDB package names mariadb-server and mariadb

RHEL 9 uses lowercase mariadb-server (server) and mariadb (client). Previous MariaDB-server / MariaDB-client naming was incorrect for this platform.

See: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/configuring_and_using_database_servers/index